### PR TITLE
fix: lowercase GHCR org name (L-Town-FC -> l-town-fc)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -39,7 +39,7 @@ permissions:
   packages: write
 
 env:
-  IMAGE_NAME: ghcr.io/L-Town-FC/the-will-of-the-people
+  IMAGE_NAME: ghcr.io/l-town-fc/the-will-of-the-people
   DEV_PI_HOSTNAME: rpi3
   PROD_PI_HOSTNAME: rpi5
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ npm run lint              # lint codebase
 
 ## Building and deploying
 
-Docker images are published to GHCR (`ghcr.io/L-Town-FC/the-will-of-the-people`):
+Docker images are published to GHCR (`ghcr.io/l-town-fc/the-will-of-the-people`):
 
 ```bash
 make build         # build and push single-arch

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for full details.
 
 ## Deployment
 
-Docker images are published to **GitHub Container Registry** (`ghcr.io/L-Town-FC/the-will-of-the-people`) — no Docker Hub credentials needed.
+Docker images are published to **GitHub Container Registry** (`ghcr.io/l-town-fc/the-will-of-the-people`) — no Docker Hub credentials needed.
 
 ### Release workflow
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.io/L-Town-FC/the-will-of-the-people
+    image: ghcr.io/l-town-fc/the-will-of-the-people
     restart: unless-stopped
     environment:
       NODE_ENV: production


### PR DESCRIPTION
GHCR requires lowercase repository names. The org name `L-Town-FC` was causing `repository name must be lowercase` errors during docker build.\n\nUpdated in: build-and-deploy.yml, docker-compose.yml, scripts/image-version.sh, README.md, CONTRIBUTING.md