### PR TITLE
fix: lowercase GHCR org in image-version.sh

### DIFF
--- a/scripts/image-version.sh
+++ b/scripts/image-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-repo="${DOCKER_REPO:-ghcr.io/L-Town-FC}"
+repo="${DOCKER_REPO:-ghcr.io/l-town-fc}"
 name="${IMAGE_NAME:-bot}"
 
 resolve_image_tags() {


### PR DESCRIPTION
Missed this file in the previous fix. The `scripts/image-version.sh` default repo was still uppercase.