### PR TITLE
chore: add workflow to make GHCR package public

### DIFF
--- a/.github/workflows/set-package-visibility.yml
+++ b/.github/workflows/set-package-visibility.yml
@@ -1,0 +1,18 @@
+name: Set GHCR Package Visibility
+
+on: workflow_dispatch
+
+permissions:
+  packages: write
+
+jobs:
+  set-visibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Make GHCR package public
+        run: |
+          gh api \
+            --method PUT \
+            -H "Accept: application/vnd.github+json" \
+            "/orgs/l-town-fc/packages/container/the-will-of-the-people/visibility" \
+            -f visibility="public"


### PR DESCRIPTION
One-off workflow to set GHCR package visibility to public so unauthenticated pulls work.