### PR TITLE
fix: add GH_TOKEN env var to visibility workflow

### DIFF
--- a/.github/workflows/set-package-visibility.yml
+++ b/.github/workflows/set-package-visibility.yml
@@ -8,6 +8,8 @@ permissions:
 jobs:
   set-visibility:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Make GHCR package public
         run: |


### PR DESCRIPTION
The GITHUB_TOKEN wasn't being passed to gh CLI.