### PR TITLE
feat: add docker-compose dev profile for local GHCR container testing

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,13 @@
+services:
+  bot:
+    container_name: bot-dev
+    image: ghcr.io/l-town-fc/the-will-of-the-people:latest
+    restart: unless-stopped
+    env_file: local.dev.env
+    environment:
+      NODE_ENV: local
+    volumes:
+      - bot-dev-vol:/usr/src/bot/volume
+
+volumes:
+  bot-dev-vol:

--- a/makefile
+++ b/makefile
@@ -57,3 +57,18 @@ compose-logs:
 
 compose-down:
 	docker compose down
+
+compose-dev-pull:
+	docker compose -f docker-compose.dev.yml pull
+
+compose-dev-up:
+	docker compose -f docker-compose.dev.yml up -d --pull missing
+
+compose-dev-restart:
+	docker compose -f docker-compose.dev.yml up -d --pull always
+
+compose-dev-logs:
+	docker compose -f docker-compose.dev.yml logs -f bot
+
+compose-dev-down:
+	docker compose -f docker-compose.dev.yml down


### PR DESCRIPTION
Adds `docker-compose.dev.yml` and `make compose-dev-*&#96; targets for running the GHCR-published image locally with the dev bot token from `local.dev.env`.